### PR TITLE
Regtest

### DIFF
--- a/breadwallet.xcodeproj/project.pbxproj
+++ b/breadwallet.xcodeproj/project.pbxproj
@@ -4511,7 +4511,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"BITCOIN_REGTEST=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",
@@ -5478,7 +5477,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"BITCOIN_REGTEST=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",
@@ -5777,7 +5775,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"BITCOIN_REGTEST=1",
+					"BITCOIN_TESTNET=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",

--- a/breadwallet.xcodeproj/project.pbxproj
+++ b/breadwallet.xcodeproj/project.pbxproj
@@ -4511,6 +4511,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"BITCOIN_REGTEST=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",
@@ -4929,6 +4930,305 @@
 			};
 			name = Release;
 		};
+		8172C7831F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(SDK_DIR)/usr/include $(SRCROOT)/Modules $(SRCROOT)/breadwallet/src/Platform";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Regtest;
+		};
+		8172C7841F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = breadwallet/breadwallet.entitlements;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/**";
+				INFOPLIST_FILE = breadwallet/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-DDebug -DRegtest";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Regtest;
+		};
+		8172C7851F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = breadwalletTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwalletTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/breadwallet.app/breadwallet";
+			};
+			name = Regtest;
+		};
+		8172C7861F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = breadwalletUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwalletUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = breadwallet;
+			};
+			name = Regtest;
+		};
+		8172C7871F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				IBSC_MODULE = breadwallet_WatchKit_Extension;
+				INFOPLIST_FILE = "breadwallet WatchKit App/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = Regtest;
+		};
+		8172C7881F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = "breadwallet WatchKit Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = Regtest;
+		};
+		8172C7891F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = MessagesExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet.MessagesExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Regtest;
+		};
+		8172C78A1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = TodayExtension/TodayExtension.entitlements;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = TodayExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet.TodayExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Regtest;
+		};
+		8172C78B1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine.breadwallet.NotificationServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Regtest;
+		};
+		8172C78C1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				HEADER_SEARCH_PATHS = (
+					"${SRCROOT}/Modules/unbound",
+					"${SRCROOT}/Modules/nettle",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Regtest;
+		};
+		8172C78D1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_COMMA = NO;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"BITCOIN_REGTEST=1",
+				);
+				HEADER_SEARCH_PATHS = (
+					"${SRCROOT}/Modules/breadwallet-core",
+					"${SRCROOT}/Modules/breadwallet-core/secp256k1",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Regtest;
+		};
+		8172C78E1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				HEADER_SEARCH_PATHS = "${SRCROOT}/Modules/nettle";
+				OTHER_CFLAGS = "-DHAVE_CONFIG_H=1";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				USE_HEADERMAP = NO;
+			};
+			name = Regtest;
+		};
+		8172C78F1F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Regtest;
+		};
+		8172C7901F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Modules/libbz2/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"MODULEMAP_FILE[sdk=iphoneos*]" = "$(SRCROOT)/Modules/libbz2/iphone.modulemap";
+				"MODULEMAP_FILE[sdk=iphonesimulator*]" = "$(SRCROOT)/Modules/libbz2/iphonesim.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.breadwallet.libbz2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Regtest;
+		};
+		8172C7911F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Modules/sqlite3/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				"MODULEMAP_FILE[sdk=iphoneos*]" = "$(SRCROOT)/Modules/sqlite3/iphone.modulemap";
+				"MODULEMAP_FILE[sdk=iphonesimulator*]" = "$(SRCROOT)/Modules/sqlite3/iphonesim.modulemap";
+				PRODUCT_BUNDLE_IDENTIFIER = com.breadwallet.sqlite3;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Regtest;
+		};
+		8172C7921F37E1D800198D2C /* Regtest */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				DEVELOPMENT_TEAM = 4R7S6N88W9;
+				INFOPLIST_FILE = Screenshots/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.voisine..Screenshots;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = breadwallet;
+			};
+			name = Regtest;
+		};
 		CEA7E6821F09A9D2001F8C27 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5178,7 +5478,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"BITCOIN_TESTNET=1",
+					"BITCOIN_REGTEST=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",
@@ -5477,7 +5777,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"BITCOIN_TESTNET=1",
+					"BITCOIN_REGTEST=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"${SRCROOT}/Modules/breadwallet-core",
@@ -5851,6 +6151,7 @@
 			buildConfigurations = (
 				22A9A9A01DF63426000F0016 /* Debug */,
 				CEA7E6A81F0AAA84001F8C27 /* Testnet */,
+				8172C7901F37E1D800198D2C /* Regtest */,
 				CEA7E6951F09AC6A001F8C27 /* Screenshots */,
 				22A9A9A11DF63426000F0016 /* Release */,
 				CEE0EF611EBF8D7F0018DB36 /* Testflight */,
@@ -5863,6 +6164,7 @@
 			buildConfigurations = (
 				752FB0481DF8BE6B009086FB /* Debug */,
 				CEA7E6A91F0AAA84001F8C27 /* Testnet */,
+				8172C7911F37E1D800198D2C /* Regtest */,
 				CEA7E6961F09AC6A001F8C27 /* Screenshots */,
 				752FB0491DF8BE6B009086FB /* Release */,
 				CEE0EF621EBF8D7F0018DB36 /* Testflight */,
@@ -5875,6 +6177,7 @@
 			buildConfigurations = (
 				755CD9CB1DAA18420075898E /* Debug */,
 				CEA7E6A41F0AAA84001F8C27 /* Testnet */,
+				8172C78C1F37E1D800198D2C /* Regtest */,
 				CEA7E6911F09AC6A001F8C27 /* Screenshots */,
 				755CD9CC1DAA18420075898E /* Release */,
 				CEE0EF5D1EBF8D7F0018DB36 /* Testflight */,
@@ -5887,6 +6190,7 @@
 			buildConfigurations = (
 				755CD9D81DAA197D0075898E /* Debug */,
 				CEA7E6A51F0AAA84001F8C27 /* Testnet */,
+				8172C78D1F37E1D800198D2C /* Regtest */,
 				CEA7E6921F09AC6A001F8C27 /* Screenshots */,
 				755CD9D91DAA197D0075898E /* Release */,
 				CEE0EF5E1EBF8D7F0018DB36 /* Testflight */,
@@ -5899,6 +6203,7 @@
 			buildConfigurations = (
 				759DA0D81DAC8668008CC49B /* Debug */,
 				CEA7E6A71F0AAA84001F8C27 /* Testnet */,
+				8172C78F1F37E1D800198D2C /* Regtest */,
 				CEA7E6941F09AC6A001F8C27 /* Screenshots */,
 				759DA0D91DAC8668008CC49B /* Release */,
 				CEE0EF601EBF8D7F0018DB36 /* Testflight */,
@@ -5911,6 +6216,7 @@
 			buildConfigurations = (
 				75A2A7D91DA5934400A983D8 /* Debug */,
 				CEA7E69B1F0AAA84001F8C27 /* Testnet */,
+				8172C7831F37E1D800198D2C /* Regtest */,
 				CEA7E6881F09AC6A001F8C27 /* Screenshots */,
 				75A2A7DA1DA5934400A983D8 /* Release */,
 				CEE0EF541EBF8D7F0018DB36 /* Testflight */,
@@ -5923,6 +6229,7 @@
 			buildConfigurations = (
 				75A2A7DC1DA5934400A983D8 /* Debug */,
 				CEA7E6A01F0AAA84001F8C27 /* Testnet */,
+				8172C7881F37E1D800198D2C /* Regtest */,
 				CEA7E68D1F09AC6A001F8C27 /* Screenshots */,
 				75A2A7DD1DA5934400A983D8 /* Release */,
 				CEE0EF591EBF8D7F0018DB36 /* Testflight */,
@@ -5935,6 +6242,7 @@
 			buildConfigurations = (
 				75A2A7E01DA5934400A983D8 /* Debug */,
 				CEA7E69F1F0AAA84001F8C27 /* Testnet */,
+				8172C7871F37E1D800198D2C /* Regtest */,
 				CEA7E68C1F09AC6A001F8C27 /* Screenshots */,
 				75A2A7E11DA5934400A983D8 /* Release */,
 				CEE0EF581EBF8D7F0018DB36 /* Testflight */,
@@ -5947,6 +6255,7 @@
 			buildConfigurations = (
 				75A2A7E41DA5934400A983D8 /* Debug */,
 				CEA7E69C1F0AAA84001F8C27 /* Testnet */,
+				8172C7841F37E1D800198D2C /* Regtest */,
 				CEA7E6891F09AC6A001F8C27 /* Screenshots */,
 				75A2A7E51DA5934400A983D8 /* Release */,
 				CEE0EF551EBF8D7F0018DB36 /* Testflight */,
@@ -5959,6 +6268,7 @@
 			buildConfigurations = (
 				75A2A7E71DA5934400A983D8 /* Debug */,
 				CEA7E69D1F0AAA84001F8C27 /* Testnet */,
+				8172C7851F37E1D800198D2C /* Regtest */,
 				CEA7E68A1F09AC6A001F8C27 /* Screenshots */,
 				75A2A7E81DA5934400A983D8 /* Release */,
 				CEE0EF561EBF8D7F0018DB36 /* Testflight */,
@@ -5971,6 +6281,7 @@
 			buildConfigurations = (
 				75A2A7EA1DA5934400A983D8 /* Debug */,
 				CEA7E69E1F0AAA84001F8C27 /* Testnet */,
+				8172C7861F37E1D800198D2C /* Regtest */,
 				CEA7E68B1F09AC6A001F8C27 /* Screenshots */,
 				75A2A7EB1DA5934400A983D8 /* Release */,
 				CEE0EF571EBF8D7F0018DB36 /* Testflight */,
@@ -5983,6 +6294,7 @@
 			buildConfigurations = (
 				75A2A8011DA5935F00A983D8 /* Debug */,
 				CEA7E6A11F0AAA84001F8C27 /* Testnet */,
+				8172C7891F37E1D800198D2C /* Regtest */,
 				CEA7E68E1F09AC6A001F8C27 /* Screenshots */,
 				75A2A8021DA5935F00A983D8 /* Release */,
 				CEE0EF5A1EBF8D7F0018DB36 /* Testflight */,
@@ -5995,6 +6307,7 @@
 			buildConfigurations = (
 				75A2A8161DA5936F00A983D8 /* Debug */,
 				CEA7E6A21F0AAA84001F8C27 /* Testnet */,
+				8172C78A1F37E1D800198D2C /* Regtest */,
 				CEA7E68F1F09AC6A001F8C27 /* Screenshots */,
 				75A2A8171DA5936F00A983D8 /* Release */,
 				CEE0EF5B1EBF8D7F0018DB36 /* Testflight */,
@@ -6007,6 +6320,7 @@
 			buildConfigurations = (
 				75A2A8251DA5938500A983D8 /* Debug */,
 				CEA7E6A31F0AAA84001F8C27 /* Testnet */,
+				8172C78B1F37E1D800198D2C /* Regtest */,
 				CEA7E6901F09AC6A001F8C27 /* Screenshots */,
 				75A2A8261DA5938500A983D8 /* Release */,
 				CEE0EF5C1EBF8D7F0018DB36 /* Testflight */,
@@ -6019,6 +6333,7 @@
 			buildConfigurations = (
 				75C735B61DAA1C9F00251ECF /* Debug */,
 				CEA7E6A61F0AAA84001F8C27 /* Testnet */,
+				8172C78E1F37E1D800198D2C /* Regtest */,
 				CEA7E6931F09AC6A001F8C27 /* Screenshots */,
 				75C735B71DAA1C9F00251ECF /* Release */,
 				CEE0EF5F1EBF8D7F0018DB36 /* Testflight */,
@@ -6031,6 +6346,7 @@
 			buildConfigurations = (
 				CEA7E6821F09A9D2001F8C27 /* Debug */,
 				CEA7E6AA1F0AAA84001F8C27 /* Testnet */,
+				8172C7921F37E1D800198D2C /* Regtest */,
 				CEA7E6971F09AC6A001F8C27 /* Screenshots */,
 				CEA7E6831F09A9D2001F8C27 /* Release */,
 				CEA7E6841F09A9D2001F8C27 /* Testflight */,

--- a/breadwallet.xcodeproj/xcshareddata/xcschemes/Screenshots.xcscheme
+++ b/breadwallet.xcodeproj/xcshareddata/xcschemes/Screenshots.xcscheme
@@ -72,7 +72,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Screenshots"
+      buildConfiguration = "Regtest"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/breadwallet/src/Constants/Constants.swift
+++ b/breadwallet/src/Constants/Constants.swift
@@ -40,6 +40,6 @@ struct C {
     static let feedbackEmail = "feedback@breadwallet.com"
     static let reviewLink = "https://itunes.apple.com/app/breadwallet-bitcoin-wallet/id885251393?action=write-review"
     static var standardPort: Int {
-        return E.isTestnet ? 18333 : 8333
+        return E.isTestnet ? 18333 : (E.isRegtest ? 18444 : 8333);
     }
 }

--- a/breadwallet/src/Environment.swift
+++ b/breadwallet/src/Environment.swift
@@ -9,6 +9,13 @@
 import UIKit
 
 struct E {
+    static let isRegtest: Bool = {
+        #if Regtest
+            return true
+        #else
+            return false
+        #endif
+    }()
     static let isTestnet: Bool = {
         #if Testnet
             return true

--- a/breadwallet/src/Platform/BRAPIClient.swift
+++ b/breadwallet/src/Platform/BRAPIClient.swift
@@ -164,6 +164,7 @@ open class BRAPIClient : NSObject, URLSessionDelegate, URLSessionTaskDelegate, B
     private func decorateRequest(_ request: URLRequest) -> URLRequest {
         var actualRequest = request
         actualRequest.setValue("\(E.isTestnet ? 1 : 0)", forHTTPHeaderField: "X-Bitcoin-Testnet")
+        actualRequest.setValue("\(E.isRegtest ? 1 : 0)", forHTTPHeaderField: "X-Bitcoin-Regtest")
         actualRequest.setValue("\((E.isTestFlight || E.isDebug) ? 1 : 0)", forHTTPHeaderField: "X-Testflight")
         return actualRequest
     }

--- a/breadwallet/src/ViewControllers/Import/StartImportViewController.swift
+++ b/breadwallet/src/ViewControllers/Import/StartImportViewController.swift
@@ -12,6 +12,7 @@ import BRCore
 private let mainURL = "https://api.breadwallet.com/q/addrs/utxo"
 private let fallbackURL = "https://insight.bitpay.com/api/addrs/utxo"
 private let testnetURL = "https://test-insight.bitpay.com/api/addrs/utxo"
+private let regtestURL = "" // private
 
 class StartImportViewController : UIViewController {
 
@@ -151,7 +152,7 @@ class StartImportViewController : UIViewController {
         present(balanceActivity, animated: true, completion: {
             var key = key
             guard let address = key.address() else { return }
-            let urlString = E.isTestnet ? testnetURL : mainURL
+            let urlString = E.isTestnet ? testnetURL : ( E.isRegtest ? regtestURL : mainURL);
             let request = NSMutableURLRequest(url: URL(string: urlString)!,
                                               cachePolicy: .reloadIgnoringLocalCacheData,
                                               timeoutInterval: 20.0)

--- a/breadwallet/src/Views/AccountHeaderView.swift
+++ b/breadwallet/src/Views/AccountHeaderView.swift
@@ -55,6 +55,8 @@ class AccountHeaderView : UIView, GradientDrawable, Subscriber {
             if E.isTestnet || isWatchOnly {
                 if E.isTestnet && isWatchOnly {
                     modeLabel.text = "(Testnet - Watch Only)"
+                } else if E.isRegtest {
+                    modeLabel.text = "(Regtest)"
                 } else if E.isTestnet {
                     modeLabel.text = "(Testnet)"
                 } else if isWatchOnly {
@@ -114,7 +116,7 @@ class AccountHeaderView : UIView, GradientDrawable, Subscriber {
         search.setImage(#imageLiteral(resourceName: "SearchIcon"), for: .normal)
         search.tintColor = .white
 
-        if E.isTestnet {
+        if E.isTestnet || E.isRegtest {
             name.textColor = .red
         }
 

--- a/breadwallet/src/WalletManager+BCash.swift
+++ b/breadwallet/src/WalletManager+BCash.swift
@@ -9,7 +9,7 @@
 import Foundation
 import BRCore
 
-let bCashForkBlockHeight: UInt32 = E.isTestnet ? 1155744 : 478559 //Testnet is just a guess
+let bCashForkBlockHeight: UInt32 = E.isTestnet ? 1155744 : (E.isRegtest ? 0 : 478559) //Testnet is just a guess
 private let minFeePerKb: UInt64 = ((1000*1000 + 190)/191)
 
 class BadListener : BRWalletListener {


### PR DESCRIPTION
- main project: add build configuration Regtest: “Build Settings”->“Other Swift Flags”->“Regtest”
- BRCore: Set preprocessor macros: “Build Settings”->“Preprocessor Macros”-> “Regtest” 
- Global macro BITCOIN_REGTEST and E.isRegtest() to discern the build selected
- Set configuration for regtest: privkey, pubkey, script, magicnumber, bip32_xprv, bip32_xpub, standardport, seeds, checkpoints
- Change MAX_PROOF_OF_WORK for regtest to validate blocks
- Add your regtest seeds into BRPeerManager.c (default: regtest.example.com)