### PR TITLE
Update .gitmodules to work with latest version of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/breadwallet/breadwallet-core.git
 [submodule "Modules/swift-protobuf"]
 	path = Modules/swift-protobuf
-	url = https://github.com/breadwallet/swift-protobuf/
+	url = https://github.com/breadwallet/swift-protobuf.git


### PR DESCRIPTION
Sometime between git version 2.19.0 and 2.22.0 git changed the way it parses repository URLs in `.gitmodules`, and now `swift-protobuf` won't update after `git submodule init`ing with the slash-ending URL.

Fixed by updating the url for `swift-protocol` to end in `.git` instead of `/` in `.gitmodules`

Was receiving error:

```
$ git submodule init
Submodule 'Modules/breadwallet-core' (https://github.com/breadwallet/breadwallet-core.git) registered for path 'Modules/breadwallet-core'
Submodule 'Modules/swift-protobuf' (https://github.com/breadwallet/swift-protobuf/) registered for path 'Modules/swift-protobuf'

$ git submodule update
Cloning into '.../breadwallet-ios/Modules/breadwallet-core'...
Cloning into '.../breadwallet-ios/Modules/swift-protobuf'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/breadwallet/swift-protobuf/' into submodule path '.../breadwallet-ios/Modules/swift-protobuf' failed
Failed to clone 'Modules/swift-protobuf'. Retry scheduled
Cloning into '.../breadwallet-ios/Modules/swift-protobuf'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'https://github.com/breadwallet/swift-protobuf/' into submodule path '.../breadwallet-ios/Modules/swift-protobuf' failed
Failed to clone 'Modules/swift-protobuf' a second time, aborting
```