### PR TITLE
Capital letter for "Button.send" in Russian translation

### DIFF
--- a/breadwallet/src/Strings/ru.lproj/Localizable.strings
+++ b/breadwallet/src/Strings/ru.lproj/Localizable.strings
@@ -155,7 +155,7 @@
 /* Click this button to sell an asset */
 "Button.sell" = "Продать";
 /* send button */
-"Button.send" = "отправить";
+"Button.send" = "Отправить";
 /* Settings button label */
 "Button.settings" = "Настройки";
 /* Setup button label */


### PR DESCRIPTION
Typo in translation:
"Button.send" = "отправить" instead of "Button.send" = "Отправить".
![aB7aWX1mTbQ](https://user-images.githubusercontent.com/18665422/73791030-9f43e880-47b2-11ea-8cb6-c75fcc9b4afb.jpg)




