### PR TITLE
Fix PinPad Bottom Constraint

### DIFF
--- a/breadwallet/src/ViewControllers/SecurityCenter/UpdatePinViewController.swift
+++ b/breadwallet/src/ViewControllers/SecurityCenter/UpdatePinViewController.swift
@@ -172,11 +172,11 @@ class UpdatePinViewController: UIViewController, Subscriber {
             pinPadBackground.widthAnchor.constraint(equalToConstant: floor(view.bounds.width/3.0)*3.0),
             pinPadBackground.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             pinPadBackground.heightAnchor.constraint(equalToConstant: pinPad.height),
-            pinPadBackground.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: E.isIPhoneX ? -C.padding[3] : 0.0) ])
+            pinPadBackground.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: E.isIPhoneX ? -C.padding[3] : 0.0) ])
         pinPad.view.constrain(toSuperviewEdges: nil)
         pinPad.didMove(toParent: self)
     }
-    
+
     private func addCloudView() {
         guard type == .recoverBackup, #available(iOS 13.6, *) else { return }
         let hosting = UIHostingController(rootView: CloudBackupIcon(style: .down))


### PR DESCRIPTION
This PR fixes the pin pad position on the iPhone Max by using the safe area layout guide's bottom anchor instead of the view's bottom anchor.

Before/After:

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-02-05 at 17 51 57](https://user-images.githubusercontent.com/139272/107067137-28836600-67df-11eb-9368-ea11b627cd65.png)
